### PR TITLE
Support Pod's securityContext.fsGroupChangePolicy

### DIFF
--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -1201,6 +1201,8 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         seLinuxOptions:
                           properties:
                             level:
@@ -2909,6 +2911,8 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
+                        fsGroupChangePolicy:
+                          type: string
                         seLinuxOptions:
                           properties:
                             level:


### PR DESCRIPTION
I think I found the reason of timeouts when NFS volume is mounted: https://blog.devgenius.io/when-k8s-pods-are-stuck-mounting-large-volumes-2915e6656cb8

```
template:
  spec:
    containers:
      ...
    securityContext:
      fsGroup: 10001
      runAsGroup: 10001
      runAsNonRoot: true
      runAsUser: 10001
      fsGroupChangePolicy: "OnRootMismatch"
```

With `OnRootMismatch` the pod doesn't try to change **all** files owner in the mounted folder.

To support this, I need to update `SparkApplication` CRD. 

This change is tested in `ml-stage` (by manual editing of CRD) for the streaming data ingestion jobs that were today very slow to start because of the mounting timeouts.